### PR TITLE
Fix starter code prompt template in benchmark

### DIFF
--- a/evaluation/benchmark.py
+++ b/evaluation/benchmark.py
@@ -35,10 +35,10 @@ LCB_PROMPT_WITH_STARTER_CODE = """You will be given a question (problem specific
 
 Question: {problem_description}
 
-You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
+You will use the following starter code to write the solution to the problem and enclose your code within delimiters as follows.
 ```python
 {entry_point}
-"""
+```"""
 
 
 def has_code(response):


### PR DESCRIPTION
The `LCB_PROMPT_WITH_STARTER_CODE` template in `evaluation/benchmark.py` has two issues:

1. A stray `"` at the end of the instruction sentence
2. The code fence opened with ```python but was never closed

The without-starter-code variant closes its fence properly; the starter-code variant now does the same.